### PR TITLE
Fix test assertions no longer working correctly

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,13 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  line_length: 120
+  line_length: 120,
+  locals_without_parens: [
+    assert_hid_report: 1,
+    assert_hid_report: 2,
+    assert_hid_reports: 1,
+    assert_hid_reports: 2,
+    refute_hid_reports: 0,
+    refute_hid_reports: 1
+  ]
 ]

--- a/lib/afk/hid_report/six_key_rollover.ex
+++ b/lib/afk/hid_report/six_key_rollover.ex
@@ -11,9 +11,8 @@ defmodule AFK.HIDReport.SixKeyRollover do
 
   @behaviour AFK.HIDReport
 
-  use Bitwise
-
   import AFK.Scancode, only: [scancode: 1]
+  import Bitwise
 
   @impl AFK.HIDReport
   @spec hid_report(state :: AFK.State.t()) :: <<_::64>>

--- a/test/afk/apply_keycode/key_lock_test.exs
+++ b/test/afk/apply_keycode/key_lock_test.exs
@@ -43,7 +43,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k001)
     State.release_key(state, :k001)
 
-    assert_hid_reports([])
+    refute_hid_reports()
   end
 
   test "locking and unlocking a regular key", %{state: state} do
@@ -52,22 +52,15 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
 
     State.press_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    refute_hid_reports()
 
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {0, 0, 0, 0, 0, 0}}
   end
 
   test "locking and unlocking a modifier key", %{state: state} do
@@ -76,22 +69,15 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k004)
     State.release_key(state, :k004)
 
-    assert_hid_reports([
-      %{mods: [@left_control]}
-    ])
+    assert_hid_report %{mods: [@left_control]}
 
     State.press_key(state, :k004)
 
-    assert_hid_reports([
-      %{mods: [@left_control]}
-    ])
+    refute_hid_reports()
 
     State.release_key(state, :k004)
 
-    assert_hid_reports([
-      %{mods: [@left_control]},
-      %{mods: []}
-    ])
+    assert_hid_report %{mods: []}
   end
 
   test "locking while holding lock", %{state: state} do
@@ -99,29 +85,19 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
 
     State.press_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    refute_hid_reports()
 
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {0, 0, 0, 0, 0, 0}}
 
     State.release_key(state, :k001)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    refute_hid_reports()
   end
 
   test "locking and unlocking the same physical key on different layers", %{state: state} do
@@ -132,9 +108,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
 
     # activate layer 1
     State.press_key(state, :k003)
@@ -147,20 +121,13 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # release layer 1
     State.release_key(state, :k003)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {@a, @b, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, @b, 0, 0, 0, 0}}
 
     # unlock 'a' by tapping it again
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {@a, @b, 0, 0, 0, 0}},
-      %{keys: {0, @b, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {0, @b, 0, 0, 0, 0}}
 
     # activate layer 1
     State.press_key(state, :k003)
@@ -170,12 +137,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # release layer 1
     State.release_key(state, :k003)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {@a, @b, 0, 0, 0, 0}},
-      %{keys: {0, @b, 0, 0, 0, 0}},
-      %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {0, 0, 0, 0, 0, 0}}
   end
 
   test "locking a key and using the same physical key on different layer", %{state: state} do
@@ -186,28 +148,19 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
 
     # activate layer 1
     State.press_key(state, :k003)
     # press 'b' on layer 1
     State.press_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {@a, @b, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, @b, 0, 0, 0, 0}}
 
     # release 'b' on layer 1
     State.release_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}},
-      %{keys: {@a, @b, 0, 0, 0, 0}},
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
   end
 
   test "locking and unlocking the same physical key (modifiers) on different layers", %{state: state} do
@@ -218,9 +171,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k004)
     State.release_key(state, :k004)
 
-    assert_hid_reports([
-      %{mods: [@left_control]}
-    ])
+    assert_hid_report %{mods: [@left_control]}
 
     # activate layer 1
     State.press_key(state, :k003)
@@ -233,20 +184,13 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # release layer 1
     State.release_key(state, :k003)
 
-    assert_hid_reports([
-      %{mods: [@left_control]},
-      %{mods: [@left_control, @left_shift]}
-    ])
+    assert_hid_report %{mods: [@left_control, @left_shift]}
 
     # unlock 'left control' by tapping it again
     State.press_key(state, :k004)
     State.release_key(state, :k004)
 
-    assert_hid_reports([
-      %{mods: [@left_control]},
-      %{mods: [@left_control, @left_shift]},
-      %{mods: [@left_shift]}
-    ])
+    assert_hid_report %{mods: [@left_shift]}
 
     # activate layer 1
     State.press_key(state, :k003)
@@ -256,12 +200,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # release layer 1
     State.release_key(state, :k003)
 
-    assert_hid_reports([
-      %{mods: [@left_control]},
-      %{mods: [@left_control, @left_shift]},
-      %{mods: [@left_shift]},
-      %{mods: []}
-    ])
+    assert_hid_report %{mods: []}
   end
 
   test "locking and unlocking layer hold", %{state: state} do
@@ -274,9 +213,7 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # press 'b' on layer 1
     State.press_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@b, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@b, 0, 0, 0, 0, 0}}
 
     # release 'b'
     State.release_key(state, :k002)
@@ -286,11 +223,10 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     # press 'a' on layer 0
     State.press_key(state, :k002)
 
-    assert_hid_reports([
-      %{keys: {@b, 0, 0, 0, 0, 0}},
+    assert_hid_reports [
       %{keys: {0, 0, 0, 0, 0, 0}},
       %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    ]
   end
 
   test "tapping lock key again cancels pending lock", %{state: state} do
@@ -305,9 +241,9 @@ defmodule AFK.ApplyKeycode.KeyLockTest do
     State.press_key(state, :k002)
     State.release_key(state, :k002)
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{keys: {@a, 0, 0, 0, 0, 0}},
       %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    ]
   end
 end

--- a/test/afk/apply_keycode/key_test.exs
+++ b/test/afk/apply_keycode/key_test.exs
@@ -39,10 +39,10 @@ defmodule AFK.ApplyKeycode.KeyTest do
     State.press_key(state, :k001)
     State.release_key(state, :k001)
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{keys: {@a, 0, 0, 0, 0, 0}},
       %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    ]
   end
 
   test "activating the same keycode using two different physical keys", %{state: state} do
@@ -54,12 +54,12 @@ defmodule AFK.ApplyKeycode.KeyTest do
     # releasing the original instance of a releases it
     State.release_key(state, :k001)
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{keys: {@a, 0, 0, 0, 0, 0}},
       # Because no state is changing with the second press of @a, no new events
       # are sent.
       %{keys: {0, 0, 0, 0, 0, 0}}
-    ])
+    ]
   end
 
   test "pressing more than 6 keys causes later presses to be ignored", %{state: state} do
@@ -68,7 +68,7 @@ defmodule AFK.ApplyKeycode.KeyTest do
       &State.press_key(state, &1)
     )
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{keys: {@a, 0, 0, 0, 0, 0}},
       %{keys: {@a, @s, 0, 0, 0, 0}},
       %{keys: {@a, @s, @d, 0, 0, 0}},
@@ -77,7 +77,7 @@ defmodule AFK.ApplyKeycode.KeyTest do
       %{keys: {@a, @s, @d, @f, @g, @h}}
       # The 6-key HID buffer is full and cannot express that j, k, and l are
       # also all being pressed. No further HID report events are sent.
-    ])
+    ]
   end
 
   test "HID buffer ordering", %{state: state} do
@@ -94,7 +94,7 @@ defmodule AFK.ApplyKeycode.KeyTest do
     State.release_key(state, :k007)
     State.press_key(state, :k007)
 
-    assert_hid_reports([
+    assert_hid_reports [
       # press k001 - k009
       %{keys: {@a, 0, 0, 0, 0, 0}},
       %{keys: {@a, @s, 0, 0, 0, 0}},
@@ -110,6 +110,6 @@ defmodule AFK.ApplyKeycode.KeyTest do
       # releasing and pressing k007 again allows it to take one of the freed
       # spots
       %{keys: {@a, @j, @d, 0, @g, 0}}
-    ])
+    ]
   end
 end

--- a/test/afk/apply_keycode/layer_test.exs
+++ b/test/afk/apply_keycode/layer_test.exs
@@ -85,9 +85,7 @@ defmodule AFK.ApplyKeycode.LayerTest do
   test "the first layer is considered default and always active", %{state: state} do
     State.press_key(state, :k004)
 
-    assert_hid_reports([
-      %{keys: {@q, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@q, 0, 0, 0, 0, 0}}
   end
 
   describe "while holding layer 1 activation key" do
@@ -100,25 +98,21 @@ defmodule AFK.ApplyKeycode.LayerTest do
     test "press a regular key", %{state: state} do
       State.press_key(state, :k004)
 
-      assert_hid_reports([
-        %{keys: {@a, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
     end
 
     test "press a none key", %{state: state} do
       State.press_key(state, :k003)
 
       # has no effect (does not fall through to lower level)
-      assert_hid_reports([])
+      refute_hid_reports()
     end
 
     test "press a transparent key", %{state: state} do
       State.press_key(state, :k006)
 
       # falls through to lower active layer (0)
-      assert_hid_reports([
-        %{keys: {@e, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@e, 0, 0, 0, 0, 0}}
     end
 
     test "let go of layer 1 activation key", %{state: state} do
@@ -126,9 +120,7 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.press_key(state, :k004)
 
       # layer 1 no longer active, so this is layer 0 (default)
-      assert_hid_reports([
-        %{keys: {@q, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@q, 0, 0, 0, 0, 0}}
     end
   end
 
@@ -143,27 +135,21 @@ defmodule AFK.ApplyKeycode.LayerTest do
     test "press a regular key", %{state: state} do
       State.press_key(state, :k004)
 
-      assert_hid_reports([
-        %{keys: {@z, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@z, 0, 0, 0, 0, 0}}
     end
 
     test "press a transparent key that falls to layer 1 (still active)", %{state: state} do
       State.press_key(state, :k005)
 
       # falls through to lower active layer (1)
-      assert_hid_reports([
-        %{keys: {@s, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@s, 0, 0, 0, 0, 0}}
     end
 
     test "press a transparent key that falls to layer 0 (default)", %{state: state} do
       State.press_key(state, :k006)
 
       # falls through two layers to default layer (0)
-      assert_hid_reports([
-        %{keys: {@e, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@e, 0, 0, 0, 0, 0}}
     end
 
     test "let go of layer 1 activation key and press a transparent key that falls to layer 1", %{
@@ -173,9 +159,7 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.press_key(state, :k005)
 
       # layer 1 is no longer active, so it skips layer 1 and uses 0
-      assert_hid_reports([
-        %{keys: {@w, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@w, 0, 0, 0, 0, 0}}
     end
 
     test "activating layer 1 a second time", %{state: state} do
@@ -195,14 +179,14 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.press_key(state, :k005)
       State.release_key(state, :k005)
 
-      assert_hid_reports([
+      assert_hid_reports [
         %{keys: {@s, 0, 0, 0, 0, 0}},
         %{keys: {0, 0, 0, 0, 0, 0}},
         %{keys: {@s, 0, 0, 0, 0, 0}},
         %{keys: {0, 0, 0, 0, 0, 0}},
         %{keys: {@w, 0, 0, 0, 0, 0}},
         %{keys: {0, 0, 0, 0, 0, 0}}
-      ])
+      ]
     end
   end
 
@@ -217,9 +201,7 @@ defmodule AFK.ApplyKeycode.LayerTest do
     test "layer 1 is active", %{state: state} do
       State.press_key(state, :k004)
 
-      assert_hid_reports([
-        %{keys: {@a, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
     end
 
     test "toggling layer 1 again deactivates", %{state: state} do
@@ -227,9 +209,7 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.release_key(state, :k007)
       State.press_key(state, :k004)
 
-      assert_hid_reports([
-        %{keys: {@q, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@q, 0, 0, 0, 0, 0}}
     end
   end
 
@@ -239,18 +219,14 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.release_key(state, :k008)
       State.press_key(state, :k001)
 
-      assert_hid_reports([
-        %{keys: {@one, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@one, 0, 0, 0, 0, 0}}
     end
 
     test "switches the default layer as soon as it's pressed", %{state: state} do
       State.press_key(state, :k008)
       State.press_key(state, :k001)
 
-      assert_hid_reports([
-        %{keys: {@one, 0, 0, 0, 0, 0}}
-      ])
+      assert_hid_report %{keys: {@one, 0, 0, 0, 0, 0}}
     end
 
     test "switch to layer 3 as the default layer then back to 1", %{state: state} do
@@ -261,10 +237,10 @@ defmodule AFK.ApplyKeycode.LayerTest do
       State.release_key(state, :k008)
       State.press_key(state, :k004)
 
-      assert_hid_reports([
+      assert_hid_reports [
         %{keys: {@one, 0, 0, 0, 0, 0}},
         %{keys: {@one, @q, 0, 0, 0, 0}}
-      ])
+      ]
     end
   end
 end

--- a/test/afk/apply_keycode/modifier_test.exs
+++ b/test/afk/apply_keycode/modifier_test.exs
@@ -37,10 +37,10 @@ defmodule AFK.ApplyKeycode.ModifierTest do
     State.press_key(state, :k001)
     State.release_key(state, :k001)
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{mods: [@left_control]},
       %{mods: []}
-    ])
+    ]
   end
 
   test "activating the same modifier using two different physical keys", %{state: state} do
@@ -48,24 +48,16 @@ defmodule AFK.ApplyKeycode.ModifierTest do
     State.press_key(state, :k009)
 
     # left control is active
-    assert_hid_reports([
-      %{mods: [@left_control]}
-    ])
+    assert_hid_report %{mods: [@left_control]}
 
     # releasing the second instance of left control doesn't release it
     State.release_key(state, :k009)
-
-    assert_hid_reports([
-      %{mods: [@left_control]}
-    ])
+    refute_hid_reports()
 
     # releasing the original instance of left control releases it
     State.release_key(state, :k001)
 
-    assert_hid_reports([
-      %{mods: [@left_control]},
-      %{mods: []}
-    ])
+    assert_hid_report %{mode: []}
   end
 
   test "press and release multiple modifiers", %{state: state} do
@@ -77,13 +69,13 @@ defmodule AFK.ApplyKeycode.ModifierTest do
     State.release_key(state, :k002)
     State.release_key(state, :k007)
 
-    assert_hid_reports([
+    assert_hid_reports [
       %{mods: [@left_control]},
       %{mods: [@left_control, @left_shift]},
       %{mods: [@left_control, @left_shift, @right_alt]},
       %{mods: [@left_control, @left_shift, @right_alt, @right_super]},
       %{mods: [@left_control, @right_alt, @right_super]},
       %{mods: [@left_control, @right_super]}
-    ])
+    ]
   end
 end

--- a/test/afk/apply_keycode/none_test.exs
+++ b/test/afk/apply_keycode/none_test.exs
@@ -30,13 +30,13 @@ defmodule AFK.ApplyKeycode.NoneTest do
     State.press_key(state, :k001)
     State.release_key(state, :k001)
 
-    assert_hid_reports([])
+    refute_hid_reports()
   end
 
   test "pressing a non-existent key is treated as a none key-press", %{state: state} do
     State.press_key(state, :k010)
 
-    assert_hid_reports([])
+    refute_hid_reports()
   end
 
   test "pressing 6 none keys doesn't fill up the HID buffer", %{state: state} do
@@ -45,12 +45,12 @@ defmodule AFK.ApplyKeycode.NoneTest do
       &State.press_key(state, &1)
     )
 
+    refute_hid_reports()
+
     # all positions are still considered open, even though 6 keys are being
     # pressed
     State.press_key(state, :k007)
 
-    assert_hid_reports([
-      %{keys: {@a, 0, 0, 0, 0, 0}}
-    ])
+    assert_hid_report %{keys: {@a, 0, 0, 0, 0, 0}}
   end
 end

--- a/test/afk/state_test.exs
+++ b/test/afk/state_test.exs
@@ -42,12 +42,10 @@ defmodule AFK.StateTest do
     State.press_key(state, :k001)
     State.press_key(state, :k001)
 
-    assert_receive(
-      {:EXIT, ^state,
-       {%RuntimeError{
-          message: "Already pressed key pressed again! k001"
-        }, _}}
-    )
+    assert_receive {:EXIT, ^state,
+                    {%RuntimeError{
+                       message: "Already pressed key pressed again! k001"
+                     }, _}}
   end
 
   @tag :capture_log
@@ -58,11 +56,9 @@ defmodule AFK.StateTest do
     State.release_key(state, :k001)
     State.release_key(state, :k001)
 
-    assert_receive(
-      {:EXIT, ^state,
-       {%RuntimeError{
-          message: "Unpressed key released! k001"
-        }, _}}
-    )
+    assert_receive {:EXIT, ^state,
+                    {%RuntimeError{
+                       message: "Unpressed key released! k001"
+                     }, _}}
   end
 end


### PR DESCRIPTION
Not sure why it stopped working with the old way, but this fixes things to use the built-in `assert_receive`, which is probably better anyway...